### PR TITLE
Upgrade to operator-sdk 1.18.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CERT_MANAGER_LOGO_URL ?= https://github.com/cert-manager/website/raw/3998bef91af
 
 KUSTOMIZE_VERSION ?= 4.4.0
 KIND_VERSION ?= 0.11.1
-OPERATOR_SDK_VERSION ?= 1.17.0
+OPERATOR_SDK_VERSION ?= 1.18.1
 OPM_VERSION ?= 1.20.0
 
 comma := ,

--- a/bundle/bundle.Dockerfile
+++ b/bundle/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cert-manager
 LABEL operators.operatorframework.io.bundle.channels.v1=candidate,stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.16.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.18.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=unknown
 

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -68,9 +68,9 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.7.1
-    createdAt: '2022-03-16T13:38:50'
+    createdAt: '2022-03-29T15:07:17'
     olm.skipRange: '>=1.7.0 <1.7.1'
-    operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
     operators.operatorframework.io/internal-objects: |-
       [
         "challenges.acme.cert-manager.io",

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: cert-manager
   operators.operatorframework.io.bundle.channels.v1: candidate,stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.16.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.18.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: unknown
 

--- a/hack/fixup-cert-manager-manifests
+++ b/hack/fixup-cert-manager-manifests
@@ -12,6 +12,8 @@ compatible with OLM.
   Retain only the description fields of the stored API version with the exception of descriptions related to podTemplate,
   because those are so verbose and repeated multiple times.
 
+* Add a fake deployment with control-plane: controller-manager to work around: https://github.com/operator-framework/operator-sdk/issues/5574
+
 Usage:
   hack/fixup-cert-manager-manifests  < build/cert-manager-1.4.0.upstream.yaml > build/cert-manager-1.4.0.olm.yaml
 """
@@ -52,6 +54,33 @@ def remove_descriptions_from_non_storage_versions_in_crd(crd):
         crd_versions[i] = remove_descriptions(crd_version, keep=crd_version.get("storage"))
 
 
+FAKE_DEPLOYMENT = """
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: unused-deployment
+  namespace: cert-manager
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: unused
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/name: unused
+  template:
+    metadata:
+      labels:
+        app: cainjector
+        app.kubernetes.io/component: unused
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/name: unused
+    spec:
+      containers:
+      -  name: manager
+"""
+
 def main():
     """
     Strip duplicate description fields from all supplied CRD files.
@@ -61,6 +90,7 @@ def main():
             remove_descriptions_from_non_storage_versions_in_crd(doc)
         yaml.safe_dump(doc, sys.stdout)
         sys.stdout.write("---\n")
+    sys.stdout.write(FAKE_DEPLOYMENT)
 
 
 if __name__ == "__main__":

--- a/hack/fixup-csv
+++ b/hack/fixup-csv
@@ -131,11 +131,20 @@ def main():
     for webhook in doc["spec"]["webhookdefinitions"]:
         webhook["generateName"] = prefixes[webhook["type"]] + "." + "webhooks.cert-manager.io"
 
+
+    # Remove the deployment added earlier in fixup-cert-manager-manifests to
+    # work around:
+    # https://github.com/operator-framework/operator-sdk/issues/5574
+    deployments = doc["spec"]["install"]["spec"]["deployments"]
+    for i, deployment in enumerate(deployments):
+        if deployment["name"] == "unused-deployment":
+            del deployments[i]
+
     # Workaround for OLM configuring all the webhook DNS names with a `-service` suffix.
     # See:
     # https://github.com/operator-framework/operator-lifecycle-manager/blob/15790a8a2f07fe65a3dbf5a45a54d35e20f2cce9/pkg/controller/install/webhook.go#L254
     # https://github.com/operator-framework/api/blob/b51286920978aa99422358a3db74392437eaadf0/pkg/operators/v1alpha1/clusterserviceversion_types.go#L207
-    for deployment in doc["spec"]["install"]["spec"]["deployments"]:
+    for deployment in deployments:
         # [0]["spec"]["template"]["spec"]["containers"][0]["image"]
         if deployment["name"] != "cert-manager-webhook":
             continue


### PR DESCRIPTION
This brings some new bundle validation checks which might be useful.
 * https://github.com/operator-framework/operator-sdk/releases/tag/v1.18.0

I've had to work around a new bug in operator-sdk 1.18 which makes it incompatible with non-operator-sdk generated projects.
 * https://github.com/operator-framework/operator-sdk/issues/5574