### PR TITLE
Operator sdk 1.19.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CERT_MANAGER_LOGO_URL ?= https://github.com/cert-manager/website/raw/3998bef91af
 
 KUSTOMIZE_VERSION ?= 4.4.0
 KIND_VERSION ?= 0.11.1
-OPERATOR_SDK_VERSION ?= 1.17.0
+OPERATOR_SDK_VERSION ?= 1.19.1
 OPM_VERSION ?= 1.20.0
 
 comma := ,

--- a/bundle/bundle.Dockerfile
+++ b/bundle/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cert-manager
 LABEL operators.operatorframework.io.bundle.channels.v1=candidate,stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.16.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.19.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=unknown
 

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -68,9 +68,9 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.7.2
-    createdAt: '2022-03-29T11:41:43'
+    createdAt: '2022-04-28T14:42:24'
     olm.skipRange: '>=1.7.0 <1.7.2'
-    operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
     operators.operatorframework.io/internal-objects: |-
       [
         "challenges.acme.cert-manager.io",
@@ -616,7 +616,13 @@ spec:
           - create
         serviceAccountName: cert-manager-webhook
       deployments:
-      - name: cert-manager
+      - label:
+          app: cert-manager
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/instance: cert-manager
+          app.kubernetes.io/name: cert-manager
+          app.kubernetes.io/version: v1.7.2
+        name: cert-manager
         spec:
           replicas: 1
           selector:
@@ -658,7 +664,13 @@ spec:
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: cert-manager
-      - name: cert-manager-cainjector
+      - label:
+          app: cainjector
+          app.kubernetes.io/component: cainjector
+          app.kubernetes.io/instance: cert-manager
+          app.kubernetes.io/name: cainjector
+          app.kubernetes.io/version: v1.7.2
+        name: cert-manager-cainjector
         spec:
           replicas: 1
           selector:
@@ -692,7 +704,13 @@ spec:
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: cert-manager-cainjector
-      - name: cert-manager-webhook
+      - label:
+          app: webhook
+          app.kubernetes.io/component: webhook
+          app.kubernetes.io/instance: cert-manager
+          app.kubernetes.io/name: webhook
+          app.kubernetes.io/version: v1.7.2
+        name: cert-manager-webhook
         spec:
           replicas: 1
           selector:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: cert-manager
   operators.operatorframework.io.bundle.channels.v1: candidate,stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.16.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.19.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: unknown
 


### PR DESCRIPTION
Supplants #64 

Upgrading to [latest operator-sdk](https://github.com/operator-framework/operator-sdk/releases/tag/v1.19.1) to pick up the latest features, bundle validation checks and bug fixes.