### PR TITLE
cert-manager v1.10.1 (operatorhub package v1.10.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ SHELL := bash
 .SUFFIXES:
 .ONESHELL:
 
-CERT_MANAGER_VERSION ?= 1.10.0
+CERT_MANAGER_VERSION ?= 1.10.1
 # Decoupled the BUNDLE_VERSION from the CERT_MANAGER_VERSION so that I can do a
 # patch release containing the fix for:
 # https://github.com/cert-manager/cert-manager/issues/5551
-export BUNDLE_VERSION ?= 1.10.1
+export BUNDLE_VERSION ?= 1.10.2
 # DO NOT PUBLISH PRE-RELEASES TO THE STABLE CHANNEL!
 # For stable releases use: `candidate stable`.
 # For pre-releases use: `candidate`.

--- a/bundle/manifests/acme.cert-manager.io_challenges.yaml
+++ b/bundle/manifests/acme.cert-manager.io_challenges.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.10.0
+    app.kubernetes.io/version: v1.10.1
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/bundle/manifests/acme.cert-manager.io_orders.yaml
+++ b/bundle/manifests/acme.cert-manager.io_orders.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.10.0
+    app.kubernetes.io/version: v1.10.1
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/bundle/manifests/cert-manager-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cert-manager-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.10.0
+    app.kubernetes.io/version: v1.10.1
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit

--- a/bundle/manifests/cert-manager-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cert-manager-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.10.0
+    app.kubernetes.io/version: v1.10.1
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/bundle/manifests/cert-manager-webhook_v1_service.yaml
+++ b/bundle/manifests/cert-manager-webhook_v1_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.10.0
+    app.kubernetes.io/version: v1.10.1
   name: cert-manager-webhook
 spec:
   ports:

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -67,9 +67,9 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Security
-    containerImage: quay.io/jetstack/cert-manager-controller:v1.10.0
-    createdAt: '2022-11-04T10:22:12'
-    olm.skipRange: '>=1.10.0 <1.10.1'
+    containerImage: quay.io/jetstack/cert-manager-controller:v1.10.1
+    createdAt: '2022-11-21T14:37:52'
+    olm.skipRange: '>=1.10.0 <1.10.2'
     operators.operatorframework.io/builder: operator-sdk-v1.25.0
     operators.operatorframework.io/internal-objects: |-
       [
@@ -84,7 +84,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: cert-manager.v1.10.1
+  name: cert-manager.v1.10.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -618,7 +618,7 @@ spec:
           app.kubernetes.io/component: controller
           app.kubernetes.io/instance: cert-manager
           app.kubernetes.io/name: cert-manager
-          app.kubernetes.io/version: v1.10.0
+          app.kubernetes.io/version: v1.10.1
         name: cert-manager
         spec:
           replicas: 1
@@ -639,7 +639,7 @@ spec:
                 app.kubernetes.io/component: controller
                 app.kubernetes.io/instance: cert-manager
                 app.kubernetes.io/name: cert-manager
-                app.kubernetes.io/version: v1.10.0
+                app.kubernetes.io/version: v1.10.1
             spec:
               containers:
               - args:
@@ -651,7 +651,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/jetstack/cert-manager-controller:v1.10.0
+                image: quay.io/jetstack/cert-manager-controller:v1.10.1
                 imagePullPolicy: IfNotPresent
                 name: cert-manager-controller
                 ports:
@@ -676,7 +676,7 @@ spec:
           app.kubernetes.io/component: cainjector
           app.kubernetes.io/instance: cert-manager
           app.kubernetes.io/name: cainjector
-          app.kubernetes.io/version: v1.10.0
+          app.kubernetes.io/version: v1.10.1
         name: cert-manager-cainjector
         spec:
           replicas: 1
@@ -693,7 +693,7 @@ spec:
                 app.kubernetes.io/component: cainjector
                 app.kubernetes.io/instance: cert-manager
                 app.kubernetes.io/name: cainjector
-                app.kubernetes.io/version: v1.10.0
+                app.kubernetes.io/version: v1.10.1
             spec:
               containers:
               - args:
@@ -704,7 +704,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/jetstack/cert-manager-cainjector:v1.10.0
+                image: quay.io/jetstack/cert-manager-cainjector:v1.10.1
                 imagePullPolicy: IfNotPresent
                 name: cert-manager-cainjector
                 resources: {}
@@ -725,7 +725,7 @@ spec:
           app.kubernetes.io/component: webhook
           app.kubernetes.io/instance: cert-manager
           app.kubernetes.io/name: webhook
-          app.kubernetes.io/version: v1.10.0
+          app.kubernetes.io/version: v1.10.1
         name: cert-manager-webhook
         spec:
           replicas: 1
@@ -742,7 +742,7 @@ spec:
                 app.kubernetes.io/component: webhook
                 app.kubernetes.io/instance: cert-manager
                 app.kubernetes.io/name: webhook
-                app.kubernetes.io/version: v1.10.0
+                app.kubernetes.io/version: v1.10.1
             spec:
               containers:
               - args:
@@ -758,7 +758,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/jetstack/cert-manager-webhook:v1.10.0
+                image: quay.io/jetstack/cert-manager-webhook:v1.10.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 3
@@ -886,7 +886,7 @@ spec:
   provider:
     name: The cert-manager maintainers
     url: https://cert-manager.io/
-  version: 1.10.1
+  version: 1.10.2
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/cert-manager.io_certificaterequests.yaml
+++ b/bundle/manifests/cert-manager.io_certificaterequests.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.10.0
+    app.kubernetes.io/version: v1.10.1
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_certificates.yaml
+++ b/bundle/manifests/cert-manager.io_certificates.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.10.0
+    app.kubernetes.io/version: v1.10.1
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_clusterissuers.yaml
+++ b/bundle/manifests/cert-manager.io_clusterissuers.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.10.0
+    app.kubernetes.io/version: v1.10.1
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_issuers.yaml
+++ b/bundle/manifests/cert-manager.io_issuers.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.10.0
+    app.kubernetes.io/version: v1.10.1
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager_v1_service.yaml
+++ b/bundle/manifests/cert-manager_v1_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.10.0
+    app.kubernetes.io/version: v1.10.1
   name: cert-manager
 spec:
   ports:


### PR DESCRIPTION
Releasing [cert-manager v1.10.1 ](https://github.com/cert-manager/cert-manager/releases/tag/v1.10.1).

- [ ] https://github.com/k8s-operatorhub/community-operators/pull/1966
- [ ] https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/1863

The OLM package version is one patch version ahead of the cert-manager version because we used OLM package version v1.10.1 to fix a bug in the OLM clusterserviceversion file. See:
 * #85 