### PR TITLE
Fix the make crc-e2e instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ E2E_TEST ?=
 
 .PHONY: crc-e2e
 crc-e2e: ## Run cert-manager E2E tests on the crc-instance
-crc-e2e: crc-instance ${E2E_TEST}
+crc-e2e: ${E2E_TEST}
 	: $${E2E_TEST:?"Please set E2E_TEST to the path to the cert-manager E2E test binary"}
 	gcloud compute ssh crc@${CRC_INSTANCE_NAME} -- rm -f ./e2e
 	gcloud compute scp --compress ${E2E_TEST} crc@${CRC_INSTANCE_NAME}:e2e

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ First compile the cert-manager E2E test binary as follows:
 
 ```sh
 cd projects/cert-manager/cert-manager
-bazel build //test/e2e:e2e
+make e2e-build
 ```
 
 And then upload the binary to the remote VM and run them against cert-manager installed in the crc OpenShift cluster:
@@ -215,9 +215,8 @@ And then upload the binary to the remote VM and run them against cert-manager in
 ```sh
 cd projects/cert-manager/cert-manager-olm
 make crc-e2e \
-  OPENSHIFT_VERSION=4.8 \
-  PULL_SECRET=~/Downloads/pull-secret \
-  E2E_TEST=../cert-manager/bazel-bin/test/e2e/e2e.test
+  OPENSHIFT_VERSION=4.X \
+  E2E_TEST=../cert-manager/_bin/test/e2e.test
 ```
 
 ### Manual Creation of a `crc` VM


### PR DESCRIPTION
The "Testing on CRC" section was out of date and the make target didn't quite work.

Depends on:
 * https://github.com/cert-manager/cert-manager/pull/5804