### PR TITLE
Annual review of the OWNERS file (2023): Maartje moved to Emeritus Maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
 approvers:
-- meyskens
 - munnerz
 - JoshVanL
 - wallrj


### PR DESCRIPTION
Ref: https://github.com/cert-manager/cert-manager/issues/6231