### PR TITLE
Fix the source repo URL

### DIFF
--- a/global-csv-config.yaml
+++ b/global-csv-config.yaml
@@ -63,7 +63,7 @@ categories:
 
 support: The cert-manager maintainers
 
-repository: https://github.com/jetstack/cert-manager
+repository: https://github.com/cert-manager/cert-manager
 
 min_kubernetes_version: 1.19.0-0
 


### PR DESCRIPTION
Thanks @amcginlay for spotting this problem with the URL in OperatorHub

<img width="960" alt="image" src="https://github.com/cert-manager/cert-manager-olm/assets/978965/6dc66b57-8c8e-4430-8080-28ab1a884eba">
