### PR TITLE
Configure the e2e.test binary for OpenShift environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ crc-e2e: ${E2E_TEST}
 	: $${E2E_TEST:?"Please set E2E_TEST to the path to the cert-manager E2E test binary"}
 	gcloud compute ssh crc@${CRC_INSTANCE_NAME} -- rm -f ./e2e
 	gcloud compute scp --compress ${E2E_TEST} crc@${CRC_INSTANCE_NAME}:e2e
-	gcloud compute ssh crc@${CRC_INSTANCE_NAME} -- ./e2e --repo-root=/dev/null --ginkgo.focus="CA\ Issuer" --ginkgo.skip="Gateway"
+	gcloud compute ssh crc@${CRC_INSTANCE_NAME} -- E2E_OPENSHIFT=true ./e2e --repo-root=/dev/null --ginkgo.focus="Vault\ Issuer" --ginkgo.skip="Gateway"
 
 
 


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/6391 I modified the cert-manager e2e test binary so that it can install the Hashicorp Vault chart on OpenShift if you set `E2E_OPENSHIFT=true` environment variable.

This PR sets that variable.

## Testing

```bash
richard@LAPTOP-HJEQ9V9G:~/projects/cert-manager/cert-manager-olm$ make crc-e2e E2E_TEST=../cert-manager/_bin/test/e2e.test
: ${E2E_TEST:?"Please set E2E_TEST to the path to the cert-manager E2E test binary"}
gcloud compute ssh crc@crc-4-13 -- rm -f ./e2e
gcloud compute scp --compress ../cert-manager/_bin/test/e2e.test crc@crc-4-13:e2e
gcloud compute ssh crc@crc-4-13 -- E2E_OPENSHIFT=true ./e2e --repo-root=/dev/null --ginkgo.focus="Vault\ Issuer" --ginkgo.skip="Gateway"
Connection to 34.140.125.216 closed.
e2e.test                                                                                  100%   44MB  17.8MB/s   00:02
Running Suite: cert-manager e2e suite - /home/crc
=================================================
Random Seed: 1696511320

Will run 25 of 777 specs
"hashicorp" already exists with the same configuration, skipping
Release "chart-vault-vault" does not exist. Installing it now.
NAME: chart-vault-vault
LAST DEPLOYED: Thu Oct  5 13:08:41 2023
NAMESPACE: e2e-vault
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing HashiCorp Vault!

Now that you have deployed Vault, you should look over the docs on using
Vault with Kubernetes available here:

https://www.vaultproject.io/docs/


Your release is named chart-vault-vault. To learn more about the release, try:

  $ helm status chart-vault-vault
  $ helm get manifest chart-vault-vault
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••••[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
        >  goroutine 310 [running]:
        >  runtime/debug.Stack()
        >       runtime/debug/stack.go:24 +0x5e
        >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/log/log.go:60 +0xcd
        >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc000051f40, {0x1da69f7, 0x14})
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/log/deleg.go:147 +0x45
        >  github.com/go-logr/logr.Logger.WithName({{0x2070db0, 0xc000051f40}, 0x0}, {0x1da69f7?, 0xc000a45d98?})
        >       github.com/go-logr/logr@v1.2.4/logr.go:336 +0x3d
        >  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x0?, {0x0, 0xc0002133b0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/client/client.go:122 +0xec
        >  sigs.k8s.io/controller-runtime/pkg/client.New(0x1dc1057?, {0x0, 0xc0002133b0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/client/client.go:103 +0x7d
        >  github.com/cert-manager/cert-manager/e2e-tests/framework.(*Framework).BeforeEach(0xc000665540)
        >       github.com/cert-manager/cert-manager/e2e-tests/framework/framework.go:145 +0x33c
        >  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3({0xa01948, 0xc000c83980})
        >       github.com/onsi/ginkgo/v2@v2.12.0/internal/node.go:463 +0x13
        >  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
        >       github.com/onsi/ginkgo/v2@v2.12.0/internal/suite.go:865 +0x8d
        >  created by github.com/onsi/ginkgo/v2/internal.(*Suite).runNode in goroutine 21
        >       github.com/onsi/ginkgo/v2@v2.12.0/internal/suite.go:852 +0xd7b
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••••••
------------------------------
• [FAILED] [60.897 seconds]
[cert-manager] Vault Issuer [It] should be ready with a valid serviceAccountRef
github.com/cert-manager/cert-manager/e2e-tests/suite/issuers/vault/issuer.go:346

  Timeline >>
  STEP: Creating a kubernetes client @ 10/05/23 13:09:57.666
  STEP: Creating an API extensions client @ 10/05/23 13:09:57.668
  STEP: Creating a cert manager client @ 10/05/23 13:09:57.668
  STEP: Creating a controller-runtime client @ 10/05/23 13:09:57.669
  STEP: Creating a gateway-api client @ 10/05/23 13:09:57.67
  STEP: Building a namespace api object @ 10/05/23 13:09:57.67
  STEP: Using the namespace e2e-tests-create-vault-issuer-7w8cg @ 10/05/23 13:09:57.716
  STEP: Building a ResourceQuota api object @ 10/05/23 13:09:57.716
  STEP: Configuring the Vault server @ 10/05/23 13:09:57.743
  STEP: creating a service account for Vault authentication @ 10/05/23 13:09:58.102
  STEP: Creating the Role and RoleBinding to let cert-manager use TokenRequest for the ServiceAccount @ 10/05/23 13:09:58.159
  STEP: Creating an Issuer @ 10/05/23 13:09:58.217
  STEP: Waiting for Issuer to become Ready @ 10/05/23 13:09:58.275
  Oct  5 13:09:58.275: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 13:10:03.348: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 13:10:09.848: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 13:10:17.350: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 13:10:26.348: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 13:10:36.847: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 13:10:49.347: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 13:10:58.282: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0} (took 1m0s)
  [FAILED] in [It] - github.com/cert-manager/cert-manager/e2e-tests/suite/issuers/vault/issuer.go:370 @ 10/05/23 13:10:58.362
  STEP: Cleaning up AppRole @ 10/05/23 13:10:58.362
  STEP: Cleaning up Kubernetes @ 10/05/23 13:10:58.456
  STEP: Cleaning up Vault @ 10/05/23 13:10:58.498
  STEP: Deleting test namespace @ 10/05/23 13:10:58.534
  << Timeline

  [FAILED] Unexpected error:
      <*errors.errorString | 0xc000bc2f70>:
      context deadline exceeded: Last Status: 'False' Reason: 'VaultError', Message: 'Failed to initialize Vault client: while requesting a Vault token using the Kubernetes auth: while requesting a token for the service account e2e-tests-create-vault-issuer-7w8cg/vault-serviceaccount: serviceaccounts "vault-serviceaccount" is forbidden: User "system:serviceaccount:openshift-operators:cert-manager" cannot create resource "serviceaccounts/token" in API group "" in the namespace "e2e-tests-create-vault-issuer-7w8cg"'
      {
          s: "context deadline exceeded: Last Status: 'False' Reason: 'VaultError', Message: 'Failed to initialize Vault client: while requesting a Vault token using the Kubernetes auth: while requesting a token for the service account e2e-tests-create-vault-issuer-7w8cg/vault-serviceaccount: serviceaccounts \"vault-serviceaccount\" is forbidden: User \"system:serviceaccount:openshift-operators:cert-manager\" cannot create resource \"serviceaccounts/token\" in API group \"\" in the namespace \"e2e-tests-create-vault-issuer-7w8cg\"'",
      }
  occurred
  In [It] at: github.com/cert-manager/cert-manager/e2e-tests/suite/issuers/vault/issuer.go:370 @ 10/05/23 13:10:58.362
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSproxy logs:


Summarizing 1 Failure:
  [FAIL] [cert-manager] Vault Issuer [It] should be ready with a valid serviceAccountRef
  github.com/cert-manager/cert-manager/e2e-tests/suite/issuers/vault/issuer.go:370

Ran 25 of 777 Specs in 160.587 seconds
FAIL! -- 24 Passed | 1 Failed | 0 Pending | 752 Skipped
--- FAIL: TestE2E (160.61s)
FAIL
```

There is one failure due to cert-manager being installed in a different namespace, but that can be fixed in a separate PR.