### PR TITLE
Add support for testing on OpenShift 4.14 using CRC 2.32.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ clean-bundle-test: ${kind}
 # on your laptop, and the version you supply will then be added to the metadata
 # of the VM so that it can be downloaded from the metadata API by the crc setup
 # scripts that run inside the VM.
-OPENSHIFT_VERSION ?= 4.13
+OPENSHIFT_VERSION ?= 4.14
 
 # The path to the pull-secret which you download from https://console.redhat.com/openshift/create/local
 PULL_SECRET ?=

--- a/hack/crc.mk
+++ b/hack/crc.mk
@@ -40,6 +40,7 @@ crc_version_4.10 := 2.6.0
 crc_version_4.11 := 2.12.0
 crc_version_4.12 := 2.19.0
 crc_version_4.13 := 2.28.0
+crc_version_4.14 := 2.32.0
 crc_version = ${crc_version_${OPENSHIFT_VERSION}}
 
 # Download the crc tarball


### PR DESCRIPTION
I want to test cert-manager v1.14.1 OperatorHub package on OpenShift 4.14,
so I'm updating the Makefile to add support for creating an OpenShift 4.14 virtual machine using the latest release of CRC (code-ready-containers).


* https://github.com/crc-org/crc/releases/tag/v2.32.0


```sh
$ make crc-instance PULL_SECRET=~/Downloads/pull-secret
: ${PULL_SECRET:?"Please set PULL_SECRET to the path to the pull-secret downloaded from https://console.redhat.com/openshift/create/local"}
gcloud compute instances create crc-4-14 \
        --enable-nested-virtualization \
        --min-cpu-platform="Intel Haswell" \
        --custom-memory 32GiB \
        --custom-cpu 8 \
        --image-family=rhel-8 \
        --image-project=rhel-cloud \
        --preemptible \
        --boot-disk-size=200GiB \
        --boot-disk-type=pd-ssd \
        --metadata-from-file=make-file=hack/crc.mk,pull-secret=/home/richard/Downloads/pull-secret,startup-script=hack/crc-instance-startup-script.sh \
        --metadata=openshift-version=4.14
until gcloud compute ssh crc@crc-4-14 -- sudo systemctl is-system-running --wait; do sleep 2; done >/dev/null
Created [https://www.googleapis.com/compute/v1/projects/jetstack-richard/zones/europe-west1-b/instances/crc-4-14].
WARNING: Some requests generated warnings:
 - Disk size: '200 GB' is larger than image size: '20 GB'. You might need to resize the root repartition manually if the operating system does not support automatic resizing. See https://cloud.google.com/compute/docs/disks/add-persistent-disk#resize_pd for details.

NAME      ZONE            MACHINE_TYPE    PREEMPTIBLE  INTERNAL_IP    EXTERNAL_IP    STATUS
crc-4-14  europe-west1-b  custom-8-32768  true         10.132.15.208  34.34.130.222  RUNNING

```


```sh
$ gcloud compute ssh crc@crc-4-14 -- -D 8080
Register this system with Red Hat Insights: insights-client --register
Create an account or view all your systems at https://red.ht/insights-dashboard
Last login: Tue Feb  6 12:48:36 2024 from 167.98.108.180

```

```sh
[crc@crc-4-14 ~]$ sudo journalctl -u google-startup-scripts.service  --output cat
...
startup-script: level=debug msg="Verified bundle hashes:\n102d7cda46443c58e239f03a449a5ecc128bd03e50b83067fe64bb3ae281dcec  crc_hyperv_4.14.8_amd64.crcbundle\nb8f023ad29ee92dee06026d93c588a9065537710399bf231a3d59ce0f8b516ec  crc_libvirt_4.14.8_amd64.crcbundle\na973e8ad44e13c9209015e78e0556d10379661baed1a71f2457148a05381527f  crc_vfkit_4.14.8_amd64.crcbundle\nab4f849ca18834899de63f590bb88822ffb007784bbba6f2986f78ee161647d8  crc_vfkit_4.14.8_arm64.crcbundle"
startup-script: level=debug msg="Downloading https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/openshift/4.14.8/crc_libvirt_4.14.8_amd64.crcbundle to /home/crc/.crc/cache/crc_libvirt_4.14.8_amd64.crcbundle"
...
startup-script: Started the OpenShift cluster.
startup-script:
startup-script: The server is accessible via web console at:
startup-script:   https://console-openshift-console.apps-crc.testing
startup-script:
startup-script: Log in as administrator:
startup-script:   Username: kubeadmin
startup-script:   Password: ...
startup-script:
startup-script: Log in as user:
startup-script:   Username: developer
startup-script:   Password: ...
startup-script:
startup-script: Use the 'oc' command line interface:
startup-script:   $ eval $(crc oc-env)
startup-script:   $ oc login -u developer https://api.crc.testing:6443
startup-script exit status 0
Finished running startup scripts.
google-startup-scripts.service: Succeeded.
```


![image](https://github.com/cert-manager/cert-manager-olm/assets/978965/4bbc01c7-97e0-436e-89b7-75f9e975e59d)
