### PR TITLE
Update all the tools and get `make bundle-test` working in GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,10 @@
+name: test
+on: [pull_request]
+jobs:
+  e2e:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: make -j1 bundle-test

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CATALOG_IMG ?= ${IMG_BASE}-olm-catalogue:${CATALOG_VERSION}
 E2E_CLUSTER_NAME ?= cert-manager-olm
 CERT_MANAGER_LOGO_URL ?= https://github.com/cert-manager/website/raw/3998bef91af7266c69f051a2f879be45eb0b3bbb/static/favicons/favicon-256.png
 
-KUSTOMIZE_VERSION ?= 4.5.7
+KUSTOMIZE_VERSION ?= 5.3.0
 KIND_VERSION ?= 0.16.0
 OPERATOR_SDK_VERSION ?= 1.33.0
 OPM_VERSION ?= 1.36.0

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ kind-cluster: ${kind}
 	 ${kind} get clusters | grep ${E2E_CLUSTER_NAME} || ${kind} create cluster --name ${E2E_CLUSTER_NAME}
 
 # Give a sense of progress by streaming all the events until the ClusterServiceVersion has been installed,
-# then check the cert-manager API.
+# then check the cert-manager API and print the detected cert-manager version.
 #
 # Also works around a bug in `cmctl check api`, where it will return success if
 # the CRDs are installed but the webhook has not been configured. See
@@ -240,6 +240,7 @@ bundle-test: ## Build bundles and test locally as described at https://operator-
 bundle-test: $(cmctl) bundle-build bundle-push catalog-build catalog-push kind-cluster deploy-olm catalog-deploy subscription-deploy
 	sed '/install strategy completed/q' < <(kubectl get events --namespace operators --watch)
 	$(cmctl) check api --wait=5m -v
+	$(cmctl) version -o yaml
 
 .PHONY: clean-kind-cluster
 clean-kind-cluster: ${kind}

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ E2E_CLUSTER_NAME ?= cert-manager-olm
 CERT_MANAGER_LOGO_URL ?= https://github.com/cert-manager/website/raw/3998bef91af7266c69f051a2f879be45eb0b3bbb/static/favicons/favicon-256.png
 
 KUSTOMIZE_VERSION ?= 5.3.0
-KIND_VERSION ?= 0.16.0
+KIND_VERSION ?= 0.21.0
 OPERATOR_SDK_VERSION ?= 1.33.0
 OPM_VERSION ?= 1.36.0
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ help: ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 OLM_PACKAGE_NAME ?= cert-manager
-IMG_BASE ?= gcr.io/jetstack-richard/cert-manager
+IMG_BASE_DEFAULT := ttl.sh/$(shell uuidgen)/cert-manager
+IMG_BASE ?= $(IMG_BASE_DEFAULT)
 BUNDLE_IMG_BASE ?= ${IMG_BASE}-olm-bundle
 BUNDLE_IMG ?= ${BUNDLE_IMG_BASE}:${BUNDLE_VERSION}
 CATALOG_IMG ?= ${IMG_BASE}-olm-catalogue:${CATALOG_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,8 @@ metadata:
 spec:
  sourceType: grpc
  image: ${CATALOG_IMG}
+ grpcPodConfig:
+  securityContextConfig: restricted
 ---
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ kind-cluster: ${kind}
 
 .PHONY: bundle-test
 bundle-test: ## Build bundles and test locally as described at https://operator-framework.github.io/community-operators/testing-operators/
-bundle-test: catalog-build catalog-push kind-cluster deploy-olm catalog-deploy subscription-deploy
+bundle-test: bundle-build bundle-push catalog-build catalog-push kind-cluster deploy-olm catalog-deploy subscription-deploy
 
 .PHONY: clean-kind-cluster
 clean-kind-cluster: ${kind}

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ CERT_MANAGER_LOGO_URL ?= https://github.com/cert-manager/website/raw/3998bef91af
 KUSTOMIZE_VERSION ?= 4.5.7
 KIND_VERSION ?= 0.16.0
 OPERATOR_SDK_VERSION ?= 1.33.0
-OPM_VERSION ?= 1.26.2
+OPM_VERSION ?= 1.36.0
 
 comma := ,
 empty :=

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ bundle-generate: ${bundle_csv}
 
 .PHONY: bundle-build
 bundle-build: ## Create a cert-manager OLM bundle image
-bundle-build: ${bundle_csv} ${bundle_dockerfile}
+bundle-build:
 	docker build -f ${bundle_dockerfile} -t ${BUNDLE_IMG} ${bundle_dir}
 
 .PHONY: bundle-push

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CERT_MANAGER_LOGO_URL ?= https://github.com/cert-manager/website/raw/3998bef91af
 
 KUSTOMIZE_VERSION ?= 4.5.7
 KIND_VERSION ?= 0.16.0
-OPERATOR_SDK_VERSION ?= 1.25.0
+OPERATOR_SDK_VERSION ?= 1.33.0
 OPM_VERSION ?= 1.26.2
 
 comma := ,

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,12 @@ ${downloadable_executables}:
 	curl --remote-time -sSL -o $@ ${url}
 	chmod +x $@
 
-build_v = build/${BUNDLE_VERSION}
+
+build := build
+$(build):
+		mkdir -p $@
+
+build_v := $(build)/${BUNDLE_VERSION}
 
 cert_manager_manifest_upstream = build/cert-manager.${CERT_MANAGER_VERSION}.upstream.yaml
 ${cert_manager_manifest_upstream}: url := https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
@@ -184,9 +189,9 @@ endef
 
 .PHONY: catalog-deploy
 catalog-deploy: ## Deploy the catalog to Kubernetes
-catalog-deploy:
-	$(file > build/catalog.yaml,${catalog_yaml})
-	kubectl apply -f build/catalog.yaml
+catalog-deploy: | $(build)
+	$(file > $(build)/catalog.yaml,$(catalog_yaml))
+	kubectl apply -f $(build)/catalog.yaml
 
 define subscription_yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/bundle/bundle.Dockerfile
+++ b/bundle/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cert-manager
 LABEL operators.operatorframework.io.bundle.channels.v1=candidate,stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=unknown
 

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -68,9 +68,9 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.13.3
-    createdAt: '2023-12-14T11:57:16'
+    createdAt: '2024-02-06T13:43:31'
     olm.skipRange: '>=1.13.0 <1.13.3'
-    operators.operatorframework.io/builder: operator-sdk-v1.25.0
+    operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/internal-objects: |-
       [
         "challenges.acme.cert-manager.io",

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: cert-manager
   operators.operatorframework.io.bundle.channels.v1: candidate,stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: unknown
 


### PR DESCRIPTION
I upgraded all the tools in the Makefile and made some changes to get `make bundle-test` working again.
And I've set up GitHub Actions to run `make bundle-test` for every PR.
This should give some additional assurance that the committed bundle sources are usable.

## Testing

```sh
$ make bundle-test
docker build -f bundle/bundle.Dockerfile -t ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3 bundle
[+] Building 0.2s (7/7) FINISHED                                                                                                                           docker:default
 => [internal] load .dockerignore                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                      0.0s
 => [internal] load build definition from bundle.Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 1.01kB                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                    0.0s
 => => transferring context: 1.21kB                                                                                                                                  0.0s
 => CACHED [1/3] COPY ./manifests /manifests/                                                                                                                        0.0s
 => CACHED [2/3] COPY ./metadata /metadata/                                                                                                                          0.0s
 => CACHED [3/3] COPY ./tests/scorecard /tests/scorecard/                                                                                                            0.0s
 => exporting to image                                                                                                                                               0.0s
 => => exporting layers                                                                                                                                              0.0s
 => => writing image sha256:357cfdc56a85a1a902e983280c689e714973989abeeed7221094d64334c9a4db                                                                         0.0s
 => => naming to ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3                                                                          0.0s
docker push ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3
The push refers to repository [ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle]
734a7f5c5b3c: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-bundle
8df19dc19944: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-bundle
299f7ad9db40: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-bundle
1.13.3: digest: sha256:ca8e9e98b1a60dd8226c852c212945fa0c1d82d51ffd2811a5a1a5c3d6e8dded size: 940
bin/opm-1.36.0 index add \
        --container-tool docker \
        --mode semver \
        --tag ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-catalogue:v1.13.3-11-g1403036 \
        --bundles ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3
WARN[0000] DEPRECATION NOTICE:
Sqlite-based catalogs and their related subcommands are deprecated. Support for
them will be removed in a future release. Please migrate your catalog workflows
to the new file-based catalog format.
INFO[0000] building the index                            bundles="[ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3]"
INFO[0000] running /usr/bin/docker pull ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3  bundles="[ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3]"
INFO[0001] running docker create                         bundles="[ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3]"
INFO[0001] running docker cp                             bundles="[ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3]"
INFO[0001] running docker rm                             bundles="[ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3]"
INFO[0001] Could not find optional dependencies file     file=bundle_tmp424721064/metadata load=annotations with=./bundle_tmp424721064
INFO[0001] Could not find optional properties file       file=bundle_tmp424721064/metadata load=annotations with=./bundle_tmp424721064
INFO[0001] Could not find optional dependencies file     file=bundle_tmp424721064/metadata load=annotations with=./bundle_tmp424721064
INFO[0001] Could not find optional properties file       file=bundle_tmp424721064/metadata load=annotations with=./bundle_tmp424721064
INFO[0001] Generating dockerfile                         bundles="[ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3]"
INFO[0001] writing dockerfile: ./index.Dockerfile1663504906  bundles="[ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3]"
INFO[0001] running docker build                          bundles="[ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3]"
INFO[0001] [docker build -f ./index.Dockerfile1663504906 -t ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-catalogue:v1.13.3-11-g1403036 .]  bundles="[ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-bundle:1.13.3]"
docker push ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-catalogue:v1.13.3-11-g1403036
The push refers to repository [ttl.sh/125c94bd-4c73-4001-9acb-2c76da828f43/cert-manager-olm-catalogue]
2fa1f4cfd5c7: Pushed
41a48f222012: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
eb9b6a6dc2ea: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
bc7135aa5d40: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
c1ccea363d30: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
4cb10dd2545b: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
d2d7ec0f6756: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
1a73b54f556b: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
e624a5370eca: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
d52f02c6501c: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
ff5700ec5418: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
accc3e6808c0: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
6fbdf253bbc2: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
54ad2ec71039: Mounted from 95e00ca5-2cf6-4b8e-a7dd-cfc0c36bfd3d/cert-manager-olm-catalogue
v1.13.3-11-g1403036: digest: sha256:832b6017f0ba0d30558214a64d9817814d778a6e08f036b387ed4dcaa2876acf size: 3240
bin/kind-0.21.0 get clusters | grep cert-manager-olm || bin/kind-0.21.0 create cluster --name cert-manager-olm
No kind clusters found.
Creating cluster "cert-manager-olm" ...
 ✓ Ensuring node image (kindest/node:v1.29.1) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-cert-manager-olm"
You can now use your cluster with:

kubectl cluster-info --context kind-cert-manager-olm

Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
bin/operator-sdk-1.33.0 olm status || bin/operator-sdk-1.33.0 olm install --timeout 5m
FATA[0000] Failed to get OLM status: error getting installed OLM version (set --version to override the default version): failed to list CSVs in namespace "olm": failed to get API group resources: unable to retrieve the complete list of server APIs: operators.coreos.com/v1alpha1: the server could not find the requested resource
INFO[0000] Fetching CRDs for version "latest"
INFO[0000] Fetching resources for resolved version "latest"
INFO[0001] Checking for existing OLM CRDs
INFO[0001] Checking for existing OLM resources
INFO[0002] Installing OLM CRDs...
INFO[0002]   Creating CustomResourceDefinition "catalogsources.operators.coreos.com"
INFO[0003]   CustomResourceDefinition "catalogsources.operators.coreos.com" created
INFO[0003]   Creating CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
INFO[0004]   CustomResourceDefinition "clusterserviceversions.operators.coreos.com" created
INFO[0004]   Creating CustomResourceDefinition "installplans.operators.coreos.com"
INFO[0005]   CustomResourceDefinition "installplans.operators.coreos.com" created
INFO[0005]   Creating CustomResourceDefinition "olmconfigs.operators.coreos.com"
INFO[0006]   CustomResourceDefinition "olmconfigs.operators.coreos.com" created
INFO[0006]   Creating CustomResourceDefinition "operatorconditions.operators.coreos.com"
INFO[0007]   CustomResourceDefinition "operatorconditions.operators.coreos.com" created
INFO[0007]   Creating CustomResourceDefinition "operatorgroups.operators.coreos.com"
INFO[0008]   CustomResourceDefinition "operatorgroups.operators.coreos.com" created
INFO[0008]   Creating CustomResourceDefinition "operators.operators.coreos.com"
INFO[0009]   CustomResourceDefinition "operators.operators.coreos.com" created
INFO[0009]   Creating CustomResourceDefinition "subscriptions.operators.coreos.com"
INFO[0010]   CustomResourceDefinition "subscriptions.operators.coreos.com" created
INFO[0011] Creating OLM resources...
INFO[0011]   Creating Namespace "olm"
INFO[0012]   Namespace "olm" created
INFO[0012]   Creating Namespace "operators"
INFO[0013]   Namespace "operators" created
INFO[0013]   Creating ServiceAccount "olm/olm-operator-serviceaccount"
INFO[0014]   ServiceAccount "olm/olm-operator-serviceaccount" created
INFO[0014]   Creating ClusterRole "system:controller:operator-lifecycle-manager"
INFO[0015]   ClusterRole "system:controller:operator-lifecycle-manager" created
INFO[0015]   Creating ClusterRoleBinding "olm-operator-binding-olm"
INFO[0016]   ClusterRoleBinding "olm-operator-binding-olm" created
INFO[0016]   Creating OLMConfig "cluster"
INFO[0017]   OLMConfig "cluster" created
INFO[0017]   Creating Deployment "olm/olm-operator"
INFO[0018]   Deployment "olm/olm-operator" created
INFO[0018]   Creating Deployment "olm/catalog-operator"
INFO[0019]   Deployment "olm/catalog-operator" created
INFO[0019]   Creating ClusterRole "aggregate-olm-edit"
INFO[0020]   ClusterRole "aggregate-olm-edit" created
INFO[0020]   Creating ClusterRole "aggregate-olm-view"
INFO[0021]   ClusterRole "aggregate-olm-view" created
INFO[0021]   Creating OperatorGroup "operators/global-operators"
INFO[0022]   OperatorGroup "operators/global-operators" created
INFO[0022]   Creating OperatorGroup "olm/olm-operators"
INFO[0023]   OperatorGroup "olm/olm-operators" created
INFO[0023]   Creating ClusterServiceVersion "olm/packageserver"
INFO[0024]   ClusterServiceVersion "olm/packageserver" created
INFO[0024]   Creating CatalogSource "olm/operatorhubio-catalog"
INFO[0025]   CatalogSource "olm/operatorhubio-catalog" created
INFO[0025] Waiting for deployment/olm-operator rollout to complete
INFO[0026]   Waiting for Deployment "olm/olm-operator" to rollout: 0 of 1 updated replicas are available
INFO[0033]   Deployment "olm/olm-operator" successfully rolled out
INFO[0033] Waiting for deployment/catalog-operator rollout to complete
INFO[0034]   Waiting for Deployment "olm/catalog-operator" to rollout: 0 of 1 updated replicas are available
INFO[0035]   Deployment "olm/catalog-operator" successfully rolled out
INFO[0035] Waiting for deployment/packageserver rollout to complete
INFO[0036]   Waiting for Deployment "olm/packageserver" to rollout: 1 of 2 updated replicas are available
INFO[0037]   Deployment "olm/packageserver" successfully rolled out
INFO[0037] Successfully installed OLM version "latest"

NAME                                            NAMESPACE    KIND                        STATUS
catalogsources.operators.coreos.com                          CustomResourceDefinition    Installed
clusterserviceversions.operators.coreos.com                  CustomResourceDefinition    Installed
installplans.operators.coreos.com                            CustomResourceDefinition    Installed
olmconfigs.operators.coreos.com                              CustomResourceDefinition    Installed
operatorconditions.operators.coreos.com                      CustomResourceDefinition    Installed
operatorgroups.operators.coreos.com                          CustomResourceDefinition    Installed
operators.operators.coreos.com                               CustomResourceDefinition    Installed
subscriptions.operators.coreos.com                           CustomResourceDefinition    Installed
olm                                                          Namespace                   Installed
operators                                                    Namespace                   Installed
olm-operator-serviceaccount                     olm          ServiceAccount              Installed
system:controller:operator-lifecycle-manager                 ClusterRole                 Installed
olm-operator-binding-olm                                     ClusterRoleBinding          Installed
cluster                                                      OLMConfig                   Installed
olm-operator                                    olm          Deployment                  Installed
catalog-operator                                olm          Deployment                  Installed
aggregate-olm-edit                                           ClusterRole                 Installed
aggregate-olm-view                                           ClusterRole                 Installed
global-operators                                operators    OperatorGroup               Installed
olm-operators                                   olm          OperatorGroup               Installed
packageserver                                   olm          ClusterServiceVersion       Installed
operatorhubio-catalog                           olm          CatalogSource               Installed


kubectl apply -f build/catalog.yaml
catalogsource.operators.coreos.com/cert-manager-test-catalog created

kubectl apply -f build/subscription.yaml
subscription.operators.coreos.com/cert-manager-subscription created
sed '/install strategy completed/q' < <(kubectl get events --namespace operators --watch)
bin/cmctl-1.13.3 check api --wait=5m -v
LAST SEEN   TYPE     REASON                OBJECT                                       MESSAGE
0s          Normal   RequirementsUnknown   clusterserviceversion/cert-manager.v1.13.3   requirements not yet checked
0s          Normal   RequirementsNotMet    clusterserviceversion/cert-manager.v1.13.3   one or more requirements couldn't be found

0s          Normal   AllRequirementsMet    clusterserviceversion/cert-manager.v1.13.3   all requirements found, attempting install
0s          Normal   ScalingReplicaSet     deployment/cert-manager                      Scaled up replica set cert-manager-64dbb75777 to 1
0s          Normal   SuccessfulCreate      replicaset/cert-manager-64dbb75777           Created pod: cert-manager-64dbb75777-hp5g2
0s          Normal   Scheduled             pod/cert-manager-64dbb75777-hp5g2            Successfully assigned operators/cert-manager-64dbb75777-hp5g2 to cert-manager-olm-control-plane
0s          Normal   ScalingReplicaSet     deployment/cert-manager-cainjector           Scaled up replica set cert-manager-cainjector-59f5fcb766 to 1
0s          Normal   SuccessfulCreate      replicaset/cert-manager-cainjector-59f5fcb766   Created pod: cert-manager-cainjector-59f5fcb766-bvhd6
0s          Normal   Scheduled             pod/cert-manager-cainjector-59f5fcb766-bvhd6    Successfully assigned operators/cert-manager-cainjector-59f5fcb766-bvhd6 to cert-manager-olm-control-plane
0s          Normal   ScalingReplicaSet     deployment/cert-manager-webhook                 Scaled up replica set cert-manager-webhook-bd8dbd74b to 1
0s          Normal   SuccessfulCreate      replicaset/cert-manager-webhook-bd8dbd74b       Created pod: cert-manager-webhook-bd8dbd74b-5449j
0s          Normal   InstallSucceeded      clusterserviceversion/cert-manager.v1.13.3      waiting for install components to report healthy
0s          Normal   Scheduled             pod/cert-manager-webhook-bd8dbd74b-5449j        Successfully assigned operators/cert-manager-webhook-bd8dbd74b-5449j to cert-manager-olm-control-plane
0s          Normal   Pulling               pod/cert-manager-64dbb75777-hp5g2               Pulling image "quay.io/jetstack/cert-manager-controller:v1.13.3"
0s          Normal   Pulling               pod/cert-manager-cainjector-59f5fcb766-bvhd6    Pulling image "quay.io/jetstack/cert-manager-cainjector:v1.13.3"
0s          Normal   InstallWaiting        clusterserviceversion/cert-manager.v1.13.3      installing: waiting for deployment cert-manager to become ready: deployment "cert-manager" not available: Deployment does not have minimum availability.
0s          Normal   Pulling               pod/cert-manager-webhook-bd8dbd74b-5449j        Pulling image "quay.io/jetstack/cert-manager-webhook:v1.13.3"
0s          Normal   Pulled                pod/cert-manager-64dbb75777-hp5g2               Successfully pulled image "quay.io/jetstack/cert-manager-controller:v1.13.3" in 3.805s (3.805s including waiting)
0s          Normal   Created               pod/cert-manager-64dbb75777-hp5g2               Created container cert-manager-controller
0s          Normal   Started               pod/cert-manager-64dbb75777-hp5g2               Started container cert-manager-controller
0s          Normal   InstallWaiting        clusterserviceversion/cert-manager.v1.13.3      installing: waiting for deployment cert-manager-cainjector to become ready: deployment "cert-manager-cainjector" not available: Deployment does not have minimum availability.
0s          Normal   Pulled                pod/cert-manager-cainjector-59f5fcb766-bvhd6    Successfully pulled image "quay.io/jetstack/cert-manager-cainjector:v1.13.3" in 3.2s (6.954s including waiting)
0s          Normal   Created               pod/cert-manager-cainjector-59f5fcb766-bvhd6    Created container cert-manager-cainjector
0s          Normal   Started               pod/cert-manager-cainjector-59f5fcb766-bvhd6    Started container cert-manager-cainjector
0s          Normal   InstallWaiting        clusterserviceversion/cert-manager.v1.13.3      installing: waiting for deployment cert-manager-webhook to become ready: deployment "cert-manager-webhook" not available: Deployment does not have minimum availability.
0s          Normal   Pulled                pod/cert-manager-webhook-bd8dbd74b-5449j        Successfully pulled image "quay.io/jetstack/cert-manager-webhook:v1.13.3" in 3.271s (10.059s including waiting)
0s          Normal   Created               pod/cert-manager-webhook-bd8dbd74b-5449j        Created container cert-manager-webhook
0s          Normal   Started               pod/cert-manager-webhook-bd8dbd74b-5449j        Started container cert-manager-webhook
0s          Normal   InstallSucceeded      clusterserviceversion/cert-manager.v1.13.3      install strategy completed with no errors
The cert-manager API is ready
```