### PR TITLE
Add 5m timeout to bundle-test and make the  computed catalog version stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ kind-cluster: ${kind}
 .PHONY: bundle-test
 bundle-test: ## Build bundles and test locally as described at https://operator-framework.github.io/community-operators/testing-operators/
 bundle-test: $(cmctl) bundle-build bundle-push catalog-build catalog-push kind-cluster deploy-olm catalog-deploy subscription-deploy
-	sed '/install strategy completed/q' < <(kubectl get events --namespace operators --watch)
+	timeout 5m sed '/install strategy completed/q' < <(kubectl get events --namespace operators --watch)
 	$(cmctl) check api --wait=5m -v
 	$(cmctl) version -o yaml
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ export BUNDLE_VERSION ?= 1.13.3
 # For pre-releases use: `candidate`.
 BUNDLE_CHANNELS ?= candidate stable
 STABLE_CHANNEL ?= stable
-CATALOG_VERSION ?= $(shell git describe --tags --always --dirty)
+CATALOG_VERSION_DEFAULT := $(shell git describe --tags --always --dirty)
+CATALOG_VERSION ?= $(CATALOG_VERSION_DEFAULT)
 OPERATORHUB_CATALOG_IMAGE ?= quay.io/operatorhubio/catalog:latest
 
 # from https://suva.sh/posts/well-documented-makefiles/


### PR DESCRIPTION
While testing https://github.com/cert-manager/cert-manager-olm/pull/105 I notice that the GitHub Action keeps running long after it is clear that the installation check has shown failures.

```
0s          Warning   BackOff               pod/cert-manager-webhook-6988db7859-fk5h5        Back-off restarting failed container cert-manager-webhook in pod cert-manager-webhook-6988db7859-fk5h5_operators(077cf6d9-b53b-48b7-bb18-da0b25eca027)
0s          Warning   BackOff               pod/cert-manager-webhook-6988db7859-fk5h5        Back-off restarting failed container cert-manager-webhook in pod cert-manager-webhook-6988db7859-fk5h5_operators(077cf6d9-b53b-48b7-bb18-da0b25eca027)
0s          Warning   BackOff               pod/cert-manager-webhook-6988db7859-fk5h5        Back-off restarting failed container cert-manager-webhook in pod cert-manager-webhook-6988db7859-fk5h5_operators(077cf6d9-b53b-48b7-bb18-da0b25eca027)
0s          Normal    Pulled                pod/cert-manager-webhook-6988db7859-fk5h5        Container image "quay.io/jetstack/cert-manager-webhook:v1.14.1" already present on machine
0s          Normal    Created               pod/cert-manager-webhook-6988db7859-fk5h5        Created container cert-manager-webhook
0s          Normal    Started               pod/cert-manager-webhook-6988db7859-fk5h5        Started container cert-manager-webhook
0s          Warning   BackOff               pod/cert-manager-webhook-6988db7859-fk5h5        Back-off restarting failed container cert-manager-webhook in pod cert-manager-webhook-6988db7859-fk5h5_operators(077cf6d9-b53b-48b7-bb18-da0b25eca027)
Error: The operation was canceled.
```
https://github.com/cert-manager/cert-manager-olm/actions/runs/7813016364/job/21311278187?pr=105


I also noticed that when I ran `make bundle-test` locally, and continued editing the files while the test was ongoing,
the computed catalog version changed between the running of an early make rule and a later make rule.
So I compute that version once when the makefile is parsed and use that as the default for all rules.