### PR TITLE
cert-manager v1.15.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL := bash
 #   successful.
 #
 # See README.md#Release Process for more details.
-CERT_MANAGER_VERSION ?= 1.15.0
+CERT_MANAGER_VERSION ?= 1.15.2
 export BUNDLE_VERSION ?= $(CERT_MANAGER_VERSION)
 
 
@@ -276,7 +276,7 @@ kind-cluster: ${kind}
 bundle-test: ## Build bundles and test locally as described at https://operator-framework.github.io/community-operators/testing-operators/
 bundle-test: $(cmctl) bundle-build bundle-push catalog-build catalog-push kind-cluster deploy-olm catalog-deploy subscription-deploy
 	timeout 5m sed '/install strategy completed/q' < <(kubectl get events --namespace operators --watch)
-	$(cmctl) check api --wait=5m 
+	$(cmctl) check api --wait=5m
 	$(cmctl) version -o yaml
 
 .PHONY: clean-kind-cluster

--- a/bundle/manifests/acme.cert-manager.io_challenges.yaml
+++ b/bundle/manifests/acme.cert-manager.io_challenges.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/bundle/manifests/acme.cert-manager.io_orders.yaml
+++ b/bundle/manifests/acme.cert-manager.io_orders.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/bundle/manifests/cert-manager-cluster-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cert-manager-cluster-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:

--- a/bundle/manifests/cert-manager-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cert-manager-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit

--- a/bundle/manifests/cert-manager-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cert-manager-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/bundle/manifests/cert-manager-webhook_v1_service.yaml
+++ b/bundle/manifests/cert-manager-webhook_v1_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
   name: cert-manager-webhook
 spec:
   ports:

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -67,8 +67,9 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Security
-    containerImage: quay.io/jetstack/cert-manager-controller:v1.15.0
-    createdAt: '2024-06-06T11:39:40'
+    containerImage: quay.io/jetstack/cert-manager-controller:v1.15.2
+    createdAt: '2024-07-30T13:50:01'
+    olm.skipRange: '>=1.15.0 <1.15.2'
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/internal-objects: |-
       [
@@ -83,7 +84,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: cert-manager.v1.15.0
+  name: cert-manager.v1.15.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -632,7 +633,7 @@ spec:
           app.kubernetes.io/component: controller
           app.kubernetes.io/instance: cert-manager
           app.kubernetes.io/name: cert-manager
-          app.kubernetes.io/version: v1.15.0
+          app.kubernetes.io/version: v1.15.2
         name: cert-manager
         spec:
           replicas: 1
@@ -653,21 +654,21 @@ spec:
                 app.kubernetes.io/component: controller
                 app.kubernetes.io/instance: cert-manager
                 app.kubernetes.io/name: cert-manager
-                app.kubernetes.io/version: v1.15.0
+                app.kubernetes.io/version: v1.15.2
             spec:
               containers:
               - args:
                 - --v=2
                 - --cluster-resource-namespace=$(POD_NAMESPACE)
                 - --leader-election-namespace=kube-system
-                - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.0
+                - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.2
                 - --max-concurrent-challenges=60
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/jetstack/cert-manager-controller:v1.15.0
+                image: quay.io/jetstack/cert-manager-controller:v1.15.2
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 8
@@ -707,7 +708,7 @@ spec:
           app.kubernetes.io/component: cainjector
           app.kubernetes.io/instance: cert-manager
           app.kubernetes.io/name: cainjector
-          app.kubernetes.io/version: v1.15.0
+          app.kubernetes.io/version: v1.15.2
         name: cert-manager-cainjector
         spec:
           replicas: 1
@@ -724,7 +725,7 @@ spec:
                 app.kubernetes.io/component: cainjector
                 app.kubernetes.io/instance: cert-manager
                 app.kubernetes.io/name: cainjector
-                app.kubernetes.io/version: v1.15.0
+                app.kubernetes.io/version: v1.15.2
             spec:
               containers:
               - args:
@@ -735,7 +736,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/jetstack/cert-manager-cainjector:v1.15.0
+                image: quay.io/jetstack/cert-manager-cainjector:v1.15.2
                 imagePullPolicy: IfNotPresent
                 name: cert-manager-cainjector
                 resources: {}
@@ -758,7 +759,7 @@ spec:
           app.kubernetes.io/component: webhook
           app.kubernetes.io/instance: cert-manager
           app.kubernetes.io/name: webhook
-          app.kubernetes.io/version: v1.15.0
+          app.kubernetes.io/version: v1.15.2
         name: cert-manager-webhook
         spec:
           replicas: 1
@@ -775,7 +776,7 @@ spec:
                 app.kubernetes.io/component: webhook
                 app.kubernetes.io/instance: cert-manager
                 app.kubernetes.io/name: webhook
-                app.kubernetes.io/version: v1.15.0
+                app.kubernetes.io/version: v1.15.2
             spec:
               containers:
               - args:
@@ -788,7 +789,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/jetstack/cert-manager-webhook:v1.15.0
+                image: quay.io/jetstack/cert-manager-webhook:v1.15.2
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 3
@@ -918,7 +919,7 @@ spec:
   provider:
     name: The cert-manager maintainers
     url: https://cert-manager.io/
-  version: 1.15.0
+  version: 1.15.2
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/cert-manager.io_certificaterequests.yaml
+++ b/bundle/manifests/cert-manager.io_certificaterequests.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_certificates.yaml
+++ b/bundle/manifests/cert-manager.io_certificates.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_clusterissuers.yaml
+++ b/bundle/manifests/cert-manager.io_clusterissuers.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_issuers.yaml
+++ b/bundle/manifests/cert-manager.io_issuers.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager_v1_service.yaml
+++ b/bundle/manifests/cert-manager_v1_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.0
+    app.kubernetes.io/version: v1.15.2
   name: cert-manager
 spec:
   ports:


### PR DESCRIPTION
Part of the cert-manager v1.15.2 release: 
 * https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1722341169119189
 * https://github.com/cert-manager/cert-manager/releases/tag/v1.15.2

OperatorHub PRs:

- [x] https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/4887
- [x] https://github.com/k8s-operatorhub/community-operators/pull/4761