### PR TITLE
Update to the latest CRC versions and add an OpenShift 4.17 option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ clean-bundle-test: ${kind}
 # on your laptop, and the version you supply will then be added to the metadata
 # of the VM so that it can be downloaded from the metadata API by the crc setup
 # scripts that run inside the VM.
-OPENSHIFT_VERSION ?= 4.14
+OPENSHIFT_VERSION ?= 4.17
 
 # The path to the pull-secret which you download from https://console.redhat.com/openshift/create/local
 PULL_SECRET ?=

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ which is more than is available on most laptops.
 Download your pull secret from the [crc-download] page and supply the path in the command line below:
 
 ```sh
-make crc-instance OPENSHIFT_VERSION=4.13 PULL_SECRET=${HOME}/Downloads/pull-secret
+make crc-instance OPENSHIFT_VERSION=4.17 PULL_SECRET=${PWD}/pull-secret
 ```
 
 This will create a VM and automatically install the chosen version of OpenShift, using a suitable version of `crc`.
@@ -135,13 +135,13 @@ The `crc` installation, setup and start are performed by a `startup-script` whic
 You can monitor the progress of the script as follows:
 
 ```sh
-gcloud compute instances tail-serial-port-output crc-4-13
+gcloud compute instances tail-serial-port-output crc-4-17
 ```
 
 You can log in to the VM and interact with the cluster as follows:
 
 ```sh
-gcloud compute ssh crc@crc-4-13 -- -D 8080
+gcloud compute ssh crc@crc-4-17 -- -D 8080
 sudo journalctl -u google-startup-scripts.service  --output cat
 eval $(bin/crc-2.28.0 oc-env)
 oc get pods -A
@@ -151,7 +151,7 @@ oc get pods -A
 
 Log in to the VM using SSH and enable socks proxy forwarding so that you will be able to connect to the Web UI of `crc` when it starts.
 ```
-gcloud compute ssh crc@crc-4-13 -- -D 8080
+gcloud compute ssh crc@crc-4-17 -- -D 8080
 ```
 
 Now configure your web browser to use the socks5 proxy at `localhost:8080`.

--- a/hack/crc.mk
+++ b/hack/crc.mk
@@ -41,6 +41,9 @@ crc_version_4.11 := 2.12.0
 crc_version_4.12 := 2.19.0
 crc_version_4.13 := 2.28.0
 crc_version_4.14 := 2.32.0
+crc_version_4.15 := 2.28.0
+crc_version_4.16 := 2.41.0
+crc_version_4.17 := 2.44.0
 crc_version = ${crc_version_${OPENSHIFT_VERSION}}
 
 # Download the crc tarball


### PR DESCRIPTION
I needed an OpenShift environment to test cert-manager and istio-csr on OpenShift,
so I made use of the make target in this repo and took the opportunity to update it with the latest CRC versions,
and to bring the VM instance up to date and to document how I chose that VM type.

```console
$ make crc-instance OPENSHIFT_VERSION=4.17 PULL_SECRET=${PWD}/pull-secret
: ${PULL_SECRET:?"Please set PULL_SECRET to the path to the pull-secret downloaded from https://console.redhat.com/openshift/create/local"}
gcloud compute instances create crc-4-17 \
        --enable-nested-virtualization \
        --min-cpu-platform="Intel Haswell" \
        --custom-memory 32GiB \
        --custom-cpu 8 \
        --image-family=rhel-8 \
        --image-project=rhel-cloud \
        --preemptible \
        --boot-disk-size=200GiB \
        --boot-disk-type=pd-ssd \
        --metadata-from-file=make-file=hack/crc.mk,pull-secret=/home/richard/projects/cert-manager/cert-manager-olm/pull-secret,startup-script=hack/crc-instance-startup-script.sh \
        --metadata=openshift-version=4.17
until gcloud compute ssh crc@crc-4-17 -- sudo systemctl is-system-running --wait; do sleep 2; done >/dev/null
Created [https://www.googleapis.com/compute/v1/projects/jetstack-richard/zones/europe-west1-b/instances/crc-4-17].
WARNING: Some requests generated warnings:
 - Disk size: '200 GB' is larger than image size: '20 GB'. You might need to resize the root repartition manually if the operating system does not support automatic resizing. See https://cloud.google.com/compute/docs/disks/add-persistent-disk#resize_pd for details.

NAME      ZONE            MACHINE_TYPE    PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP    STATUS
crc-4-17  europe-west1-b  custom-8-32768  true         10.132.0.44  34.38.116.148  RUNNING
```


```console
$ gcloud compute ssh crc@crc-4-17 -- -D 8080
Last login: Fri Nov 29 17:12:08 2024 from 167.98.108.180
[crc@crc-4-17 ~]$ sudo journalctl -u google-startup-scripts.service  --output cat
Starting Google Compute Engine Startup Scripts...
Starting startup scripts (version 20241031.00).
Found startup-script in metadata.
...
startup-script: curl --fail --silent --show-error --location --output build/crc-linux-amd64.tar.xz.2.44.0 https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/2.44.0/crc-linux-amd64.tar.xz
startup-script: mkdir -p  bin/
startup-script: tar --strip-components 1 --directory bin/ --extract --file \
startup-script:         build/crc-linux-amd64.tar.xz.2.44.0 crc-linux-2.44.0-amd64/crc
...
startup-script: level=debug msg="Downloading https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/openshift/4.17.3/crc_libvirt_4.17.3_amd64.crcbundle to /home/crc/.crc/cache/crc_libvirt_4.17.3_amd64.crcbundle"
startup-script: level=debug msg="Download saved to /home/crc/.crc/cache/crc_libvirt_4.17.3_amd64.crcbundle"
startup-script: level=info msg="Uncompressing /home/crc/.crc/cache/crc_libvirt_4.17.3_amd64.crcbundle"
startup-script: level=debug msg="Uncompressing /home/crc/.crc/cache/crc_libvirt_4.17.3_amd64.crcbundle to /home/crc/.crc/cache/tmp-extract"
```